### PR TITLE
Add private app support

### DIFF
--- a/lib/hubspot/config.rb
+++ b/lib/hubspot/config.rb
@@ -3,7 +3,7 @@ require 'logger'
 module Hubspot
   class Config
 
-    CONFIG_KEYS = [:hapikey, :base_url, :portal_id, :logger]
+    CONFIG_KEYS = [:hapikey, :base_url, :portal_id, :access_token, :logger]
     DEFAULT_LOGGER = Logger.new(nil)
 
     class << self
@@ -14,6 +14,7 @@ module Hubspot
         @hapikey = config["hapikey"]
         @base_url = config["base_url"] || "https://api.hubapi.com"
         @portal_id = config["portal_id"]
+        @access_token = config['access_token']
         @logger = config['logger'] || DEFAULT_LOGGER
         self
       end
@@ -22,6 +23,7 @@ module Hubspot
         @hapikey = nil
         @base_url = "https://api.hubapi.com"
         @portal_id = nil
+        @access_token = nil
         @logger = DEFAULT_LOGGER
       end
 

--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -5,7 +5,7 @@ module Hubspot
     class << self
       def get_json(path, opts)
         url = generate_url(path, opts)
-        response = get(url, format: :json)
+        response = get(url, headers: create_access_headers(), format: :json)
         log_request_and_response url, response
         raise(Hubspot::RequestError.new(response)) unless response.success?
         response.parsed_response
@@ -15,7 +15,7 @@ module Hubspot
         no_parse = opts[:params].delete(:no_parse) { false }
 
         url = generate_url(path, opts[:params])
-        response = post(url, body: opts[:body].to_json, headers: { 'Content-Type' => 'application/json' }, format: :json)
+        response = post(url, body: opts[:body].to_json, headers: create_access_headers(true), format: :json)
         log_request_and_response url, response, opts[:body]
         raise(Hubspot::RequestError.new(response)) unless response.success?
 
@@ -24,7 +24,7 @@ module Hubspot
 
       def put_json(path, opts)
         url = generate_url(path, opts[:params])
-        response = put(url, body: opts[:body].to_json, headers: { 'Content-Type' => 'application/json' }, format: :json)
+        response = put(url, body: opts[:body].to_json, headers: create_access_headers(true), format: :json)
         log_request_and_response url, response, opts[:body]
         raise(Hubspot::RequestError.new(response)) unless response.success?
         response.parsed_response
@@ -32,7 +32,7 @@ module Hubspot
 
       def delete_json(path, opts)
         url = generate_url(path, opts)
-        response = delete(url, format: :json)
+        response = delete(url, headers: create_access_headers(), format: :json)
         log_request_and_response url, response, opts[:body]
         raise(Hubspot::RequestError.new(response)) unless response.success?
         response
@@ -40,16 +40,36 @@ module Hubspot
 
       protected
 
+      def create_access_headers(has_request_body=false)
+        headers = {}
+        if Hubspot::Config.access_token
+          headers = { 'Authorization' => "Bearer #{Hubspot::Config.access_token}" }
+          if has_request_body 
+            headers = { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{Hubspot::Config.access_token}"}  
+          end
+        else
+          if has_request_body
+            headers = { 'Content-Type' => 'application/json' }
+          end
+        end
+        headers
+      end 
+
       def log_request_and_response(uri, response, body=nil)
         Hubspot::Config.logger.info "Hubspot: #{uri}.\nBody: #{body}.\nResponse: #{response.code} #{response.body}"
       end
 
       def generate_url(path, params={}, options={})
-        Hubspot::Config.ensure! :hapikey
+        if !Hubspot::Config.hapikey && !Hubspot::Config.access_token
+          Hubspot::Config.ensure! :access_token,:hapikey
+        end
         path = path.clone
         params = params.clone
         base_url = options[:base_url] || Hubspot::Config.base_url
-        params["hapikey"] = Hubspot::Config.hapikey unless options[:hapikey] == false
+        # if access_token is not present
+        if Hubspot::Config.hapikey
+          params["hapikey"] = Hubspot::Config.hapikey unless options[:hapikey] == false
+        end
 
         if path =~ /:portal_id/
           Hubspot::Config.ensure! :portal_id


### PR DESCRIPTION
Introduce access_token into config parameters to support private application authorization within hubspot. This was required because Hubspot has deprecated the use of API keys. Might consider removing API key support in a future PR.